### PR TITLE
Ensure compatibility with Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@ url = https://zdesk.zendesk.com
 email = you@example.com
 password = f4Pe8DBBK4K674Au7ffcp1j5t2mG7z4e1wvQE6CZ
 token = 1
-
-# note: the `token` field must be set to `1` for API auth
 ```
+
+**Note**: the `token` field must be set to `1` for **API** authentication.
 
 * [OAuth access token](https://developer.zendesk.com/rest_api/docs/support/introduction#oauth-access-token)
 ```
 [zdesk]
 url = https://zdesk.zendesk.com
 oauth = 7c6cbb4eac23cd03cf5d9b67ad23993cfb55e2f9049799adac9ada2e69567959
-
-# note: the `email` field may be omitted because the token also contains user
-# identification
 ```
 
-* Add production and sandbox credentials under separate sections, call via the
-name of each `[section]` (e.g. `zdeskcfg.get_config(section='sandbox')`)
+**Note**: the `email` field may be omitted because the token acts as a
+username & passphrase combination.
+
+Add production and sandbox credentials under separate sections, call via the
+name of each `[section]` (e.g. `zdeskcfg.get_ini_config(section='sandbox')`)
 ```
 [zdesk]
 url = https://zdesk.zendesk.com


### PR DESCRIPTION
- Replace deprecated `getargspec()` with `getfullargspec()`
- Replace deprecated `formatargspec()` with custom implementation

Copied `formatconfigargspec()` from
sicherha/powerline@6238d9e8b78f5327f60bd1d2606a37f951a3cd9c after a number of
failed attempts to use `inspect.signature` or `Signature` directly as suggested.

Resolves errors in Python 3.11 & warnings in 3.10:
```
$ python3.11 zdeskcfg.py
Traceback (most recent call last):
  File "zdeskcfg/zdeskcfg.py", line 161, in <module>
    @configure()
     ^^^^^^^^^^^
  File "zdeskcfg/zdeskcfg.py", line 36, in __call__
    tgt_argspec = inspect.getargspec(tgt_func)
                  ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?

$ python3.10 zdeskcfg.py
zdeskcfg/zdeskcfg.py:36: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  tgt_argspec = inspect.getargspec(tgt_func)
zdeskcfg/zdeskcfg.py:42: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  argspec = inspect.getargspec(tgt_func)
zdeskcfg/zdeskcfg.py:53: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  signature = inspect.formatargspec(
zdeskcfg/zdeskcfg.py:66: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  newsignature = inspect.formatargspec(*newargspec)[1:-1]
```