### PR TITLE
Ensure compatibility with Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@ url = https://zdesk.zendesk.com
 email = you@example.com
 password = f4Pe8DBBK4K674Au7ffcp1j5t2mG7z4e1wvQE6CZ
 token = 1
-
-# note: the `token` field must be set to `1` for API auth
 ```
+
+**Note**: the `token` field must be set to `1` for **API** authentication.
 
 * [OAuth access token](https://developer.zendesk.com/rest_api/docs/support/introduction#oauth-access-token)
 ```
 [zdesk]
 url = https://zdesk.zendesk.com
 oauth = 7c6cbb4eac23cd03cf5d9b67ad23993cfb55e2f9049799adac9ada2e69567959
-
-# note: the `email` field may be omitted because the token also contains user
-# identification
 ```
 
-* Add production and sandbox credentials under separate sections, call via the
-name of each `[section]` (e.g. `zdeskcfg.get_config(section='sandbox')`)
+**Note**: the `email` field may be omitted because the token acts as a
+username & passphrase combination.
+
+Add production and sandbox credentials under separate sections, call via the
+name of each `[section]` (e.g. `zdeskcfg.get_ini_config(section='sandbox')`)
 ```
 [zdesk]
 url = https://zdesk.zendesk.com

--- a/zdeskcfg.py
+++ b/zdeskcfg.py
@@ -40,7 +40,7 @@ class configure(object):
         # calling the tgt_func inside the wrapper. So, the defaults need
         # to be removed.
         signature = inspect.signature(tgt_func)
-        sig = str(signature)[1:-1].split("=")[0]
+        sig = str(signature)[1:-1].split('=')[0]
 
         # Defaults for our four new arguments that will go in the wrapper.
         newdefaults = argspec.defaults + (None, None, None, None, None, False)
@@ -141,11 +141,9 @@ class configure(object):
 
         return cfg
 
-
 def call(obj, config=os.path.join(os.path.expanduser('~'), '.zdeskcfg'),
          section=None, eager=True):
     return plac_ini.call(obj, config=config, default_section=section, eager=eager)
-
 
 def formatconfigargspec(args, varargs=None, varkw=None, defaults=None,
                         kwonlyargs=(), kwonlydefaults={}, annotations={},
@@ -174,7 +172,6 @@ def formatconfigargspec(args, varargs=None, varkw=None, defaults=None,
             spec += formatvalue(defaults[i - firstdefault])
         specs.append(spec)
     return ', '.join(specs)
-
 
 @configure()
 def __placeholder__(section=None):

--- a/zdeskcfg.py
+++ b/zdeskcfg.py
@@ -33,37 +33,24 @@ class configure(object):
         self.__config = {}
 
     def __call__(self, tgt_func):
-        tgt_argspec = inspect.getargspec(tgt_func)
-        need_self = False
-        if tgt_argspec[0][0] == 'self':
-            need_self = True
-
         name = tgt_func.__name__
-        argspec = inspect.getargspec(tgt_func)
-        if argspec[0][0] == 'self':
-            need_self = False
-        if need_self:
-            newargspec = (['self'] + argspec[0],) + argspec[1:]
-        else:
-            newargspec = argspec
+        argspec = inspect.getfullargspec(tgt_func)
 
         # This gets the original function argument names for actually
         # calling the tgt_func inside the wrapper. So, the defaults need
         # to be removed.
-        signature = inspect.formatargspec(
-                formatvalue=lambda val: "",
-                *newargspec
-                )[1:-1]
+        signature = inspect.signature(tgt_func)
+        sig = str(signature)[1:-1].split("=")[0]
 
         # Defaults for our four new arguments that will go in the wrapper.
-        newdefaults = argspec[3] + (None, None, None, None, None, False)
-        newargspec = argspec[0:3] + (newdefaults,)
+        newdefaults = argspec.defaults + (None, None, None, None, None, False)
+        newargspec = (argspec.args, argspec.varargs, argspec.varkw, newdefaults)
 
         # Add the new arguments to the argspec
         newargspec = (newargspec[0] + ['zdesk_email', 'zdesk_oauth', 'zdesk_api', 'zdesk_password', 'zdesk_url', 'zdesk_token'],) + newargspec[1:]
 
         # Text version of the arguments with their defaults
-        newsignature = inspect.formatargspec(*newargspec)[1:-1]
+        newsignature = str(formatconfigargspec(*newargspec))
 
         # Add the annotations for the new arguments to the annotations that were passed in
         self.ann.update(dict(
@@ -84,7 +71,7 @@ class configure(object):
                 '    config["zdesk_password"] = zdesk_password\n'
                 '    config["zdesk_url"] = zdesk_url\n'
                 '    config["zdesk_token"] = zdesk_token\n'
-                '    return %(tgt_func)s(%(signature)s)\n' %
+                '    return %(tgt_func)s%(signature)s\n' %
                 {'signature':signature, 'newsignature':newsignature, 'tgt_func':'tgt_func'}
             )
         evaldict = {'tgt_func' : tgt_func, 'plac' : plac, 'config' : self.__config}
@@ -154,9 +141,40 @@ class configure(object):
 
         return cfg
 
+
 def call(obj, config=os.path.join(os.path.expanduser('~'), '.zdeskcfg'),
          section=None, eager=True):
     return plac_ini.call(obj, config=config, default_section=section, eager=eager)
+
+
+def formatconfigargspec(args, varargs=None, varkw=None, defaults=None,
+                        kwonlyargs=(), kwonlydefaults={}, annotations={},
+                        formatvalue=lambda value: '=' + repr(value)):
+    """
+    Format an argument spec from the values returned by getconfigargspec.
+    This is a specialized replacement for inspect.formatargspec, which has been
+    deprecated since Python 3.5 and was removed in Python 3.11. It supports
+    valid values for args, defaults and formatvalue; all other parameters are
+    expected to be either empty or None.
+
+    sicherha/powerline@6238d9e8b78f5327f60bd1d2606a37f951a3cd9c
+    """
+    assert varargs is None
+    assert varkw is None
+    assert not kwonlyargs
+    assert not kwonlydefaults
+    assert not annotations
+
+    specs = []
+    if defaults:
+        firstdefault = len(args) - len(defaults)
+    for i, arg in enumerate(args):
+        spec = arg
+        if defaults and i >= firstdefault:
+            spec += formatvalue(defaults[i - firstdefault])
+        specs.append(spec)
+    return ', '.join(specs)
+
 
 @configure()
 def __placeholder__(section=None):


### PR DESCRIPTION
- Replace deprecated `getargspec()` with `getfullargspec()`
- Replace deprecated `formatargspec()` with custom implementation

Copied `formatconfigargspec()` from
sicherha/powerline@6238d9e8b78f5327f60bd1d2606a37f951a3cd9c after a number of
failed attempts to use `inspect.signature` or `Signature` directly as suggested.

Resolves errors in Python 3.11 & warnings in 3.10:
```
$ python3.11 zdeskcfg.py
Traceback (most recent call last):
  File "zdeskcfg/zdeskcfg.py", line 161, in <module>
    @configure()
     ^^^^^^^^^^^
  File "zdeskcfg/zdeskcfg.py", line 36, in __call__
    tgt_argspec = inspect.getargspec(tgt_func)
                  ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?

$ python3.10 zdeskcfg.py
zdeskcfg/zdeskcfg.py:36: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  tgt_argspec = inspect.getargspec(tgt_func)
zdeskcfg/zdeskcfg.py:42: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
  argspec = inspect.getargspec(tgt_func)
zdeskcfg/zdeskcfg.py:53: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  signature = inspect.formatargspec(
zdeskcfg/zdeskcfg.py:66: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  newsignature = inspect.formatargspec(*newargspec)[1:-1]
```